### PR TITLE
add missing dependency "commander"

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "bluebird": "^3.4.7",
     "chalk": "^1.1.3",
     "cli-spinner": "^0.2.5",
+    "commander": "^2.9.0",
     "fs-extra": "^1.0.0",
     "glob": "^7.1.1",
     "inquirer": "^2.0.0",


### PR DESCRIPTION
I tried to npm install + run it, and it complained of missing `commander`. This PR adds the latest version + a caret to pick up minor and patch versions.